### PR TITLE
Use debian stretch-slim and build different tags with one Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,74 +1,12 @@
-FROM node:6.14.4-alpine
+FROM node:6-stretch
 
 ENV SASS_VERSION 3.1.0
 
-# install fontcustom and sfnt2woff
-RUN apk --update add curl make gcc libc-dev zlib-dev \
- && curl -o code.zip -Ls http://pkgs.fedoraproject.org/repo/pkgs/woff/woff-code-latest.zip/1dcdbc9a7f48086185740c185d822279/woff-code-latest.zip \
-  && mkdir -p sfnt2woff \
-  && unzip -d sfnt2woff code.zip && rm code.zip \
-  && make -C sfnt2woff \
-  && mv sfnt2woff/sfnt2woff /usr/local/bin/ \
-  && rm -rf sfnt2woff \
-  && apk add ruby-json ruby ruby-dev ruby-rdoc ruby-irb \
-  && gem install fontcustom \
-  && apk del ruby-dev \
-  && apk del gcc libc-dev zlib-dev make \
-  && rm /var/cache/apk/*
+# install sfnt2woff, fontforge
+RUN set -ex && apt-get update \
+	&& apt-get install -y \
+		woff-tools fontforge \
+	&& rm -rf /var/lib/apt/lists/*
 
-# install fontforge
-# inspired by https://github.com/BWITS/Docker-builder/blob/master/fontforge/alpine/Dockerfile
-RUN apk --update add libxml2-dev alpine-sdk xz poppler-dev pango-dev m4 libtool perl autoconf automake coreutils python-dev zlib-dev freetype-dev glib-dev cmake pango && \
-    cd / && \
-    git clone https://github.com/fontforge/libspiro.git && \
-    cd libspiro && \
-    autoreconf -i && \
-    automake --foreign -Wall && \
-    ./configure && \
-    make && \
-    make install && \
-    cd / && \
-    git clone https://github.com/fontforge/libuninameslist.git && \
-    cd libuninameslist && \
-    autoreconf -i && \
-    automake --foreign && \
-    ./configure && \
-    make && \
-    make install && \
-    cd / && \
-    git clone https://github.com/BWITS/fontforge.git && \
-    cd fontforge && \
-    ./bootstrap --force && \
-    ./configure --without-iconv && \
-    make && \
-    make install && \
-    apk del alpine-sdk xz poppler-dev pango-dev m4 libtool perl autoconf automake coreutils python-dev zlib-dev freetype-dev glib-dev cmake && \
-    apk del libxml2-dev && \
-    apk add libpng python freetype glib libintl libxml2 libltdl cairo && \
-    rm /var/cache/apk/* && \
-    rm -rf /fontforge /libspiro /libuninameslist
-
-RUN apk --update add git make g++ \
-  && cd / && git clone --recursive https://github.com/google/woff2.git \
-  && cd /woff2 \
-  && make all \
-  && mv woff2_compress /usr/local/bin/ && mv woff2_decompress /usr/local/bin/ \
-  && cd / && rm -rf /woff2 \
-  && apk del git make g++ \
-  && rm /var/cache/apk/*
-
-# install git (needed for bower)
-RUN apk --update add git \
-  && npm install -g bower && npm install -g gulp  \
-  && rm /var/cache/apk/*
-
-# Install make and g++ temporary (to compile gulp-sass)
-# Note: python is already installed
-RUN apk --update add make g++ && rm /var/cache/apk/* \
-  && npm config set python /usr/bin/python2.7 \
-  && npm install gulp-sass@${SASS_VERSION} -g \
-  && apk del g++ make
-
-# Install make (needed for fontcustom)
-RUN apk --update add make \
-  && rm /var/cache/apk/*
+# Install bower gulp and gulp-sass in the desired version
+RUN set -ex && npm install -g bower gulp gulp-sass@${SASS_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
 FROM node:6-stretch-slim
 
-#ENV SASS_VERSION 3.1.0
-ENV SASS_VERSION 2.2.0
-
 # install sfnt2woff, fontforge
 RUN set -ex && apt-get update \
 	&& apt-get install -y \
 		woff-tools fontforge \
 	&& rm -rf /var/lib/apt/lists/*
-
-# Install bower gulp and gulp-sass in the desired version
-RUN set -ex \
-	&& npm install -g bower gulp gulp-sass@${SASS_VERSION} \
-	&& rm -rf /root/.npm
 
 # Install fontcustom
 RUN set -ex && apt-get update \
@@ -22,3 +14,12 @@ RUN set -ex && apt-get update \
 	&& apt-get autoremove -y \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /root/.gem
+
+# Build specific gulp-sass versions
+# (keep this at the end of the Dockerfile, in order to reuse previous layers):
+ARG SASS_VERSION
+
+# Install bower gulp and gulp-sass in the desired version
+RUN set -ex \
+	&& npm install -g bower gulp gulp-sass@${SASS_VERSION} \
+	&& rm -rf /root/.npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM node:6-stretch
+FROM node:6-stretch-slim
 
-ENV SASS_VERSION 3.1.0
+#ENV SASS_VERSION 3.1.0
+ENV SASS_VERSION 2.2.0
 
 # install sfnt2woff, fontforge
 RUN set -ex && apt-get update \
@@ -9,4 +10,15 @@ RUN set -ex && apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Install bower gulp and gulp-sass in the desired version
-RUN set -ex && npm install -g bower gulp gulp-sass@${SASS_VERSION}
+RUN set -ex \
+	&& npm install -g bower gulp gulp-sass@${SASS_VERSION} \
+	&& rm -rf /root/.npm
+
+# Install fontcustom
+RUN set -ex && apt-get update \
+	&& apt-get install -y ruby ruby-dev build-essential \
+	&& gem install fontcustom \
+	&& apt-get --purge remove -y build-essential ruby-dev \
+	&& apt-get autoremove -y \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /root/.gem

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+build: node6-sass2.2.0 node6-sass3.1.0
+
+node6-sass2.2.0:
+	docker build --build-arg SASS_VERSION=2.2.0 -t docker-node-sass:node6-sass2.2.0 .
+
+node6-sass3.1.0:
+	docker build --build-arg SASS_VERSION=3.1.0 -t docker-node-sass:node6-sass3.1.0 .

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 build: node6-sass2.2.0 node6-sass3.1.0
 
 node6-sass2.2.0:
-	docker build --build-arg SASS_VERSION=2.2.0 -t docker-node-sass:node6-sass2.2.0 .
+	docker build --build-arg SASS_VERSION=2.2.0 -t remuslazar/docker-node-sass:node6-sass2.2.0 .
 
 node6-sass3.1.0:
-	docker build --build-arg SASS_VERSION=3.1.0 -t docker-node-sass:node6-sass3.1.0 .
+	docker build --build-arg SASS_VERSION=3.1.0 -t remuslazar/docker-node-sass:node6-sass3.1.0 .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-sass Docker Image
 ===
 
-Docker Image based on `node:alpine` with node-sass support. Additionally this
+Docker Image based on `node:strech-slim` with node-sass support. Additionally this
 image also includes:
 
 * fontcustom
@@ -18,7 +18,7 @@ Use this image using `docker run`:
 
 ```bash
 docker run --rm --volumes-from davshopbase_web_1 \
-  remuslazar/docker-node-sass:2.2.0 /bin/sh -c \
+  remuslazar/docker-node-sass:node6-sass2.2.0 /bin/sh -c \
   "cd /data/www-provisioned/Packages/Sites/CRON.DavShop/Layout ; \
    mkdir -p node_modules ; \
    [ -d node_modules/gulp-sass ] || npm link gulp-sass ; \
@@ -29,28 +29,14 @@ docker run --rm --volumes-from davshopbase_web_1 \
 
 Currently there are various image tags matching the node-sass versions:
 
-* v2.2.0
-* v3.1.0 (which is also `latest`)
+* node6-sass2.2.0: with gulp-sass 2.2.0
+* node6-sass3.1.0: with gulp-sass 3.1.0
 
-E.g. to use `node-sass`@`2.2.0` use `remuslazar/docker-node-sass:v2.2.0`
-
-### Known Limitations
-
-You will not be able to compile `gulp-sass` because `g++` is missing. To do so,
-install it manually prior to the `npm install` call:
-
-```bash
-apk --update add g++ make
-```
-
-A better approach is just using the globally installed version using `npm link`
-(see above).
+E.g. to use `node-sass`@`node6-sass2.2.0` use `remuslazar/docker-node-sass:node6-sass2.2.0`
 
 ### Development
 
-```
-docker build -t remuslazar/docker-node-sass:latest .
-```
+See `Makefile` on how to build the images.
 
 ### Author
 


### PR DESCRIPTION
* Node 6.17.0
* Fontforge (20170812)
* Gulp + Bower
* Gulp Sass: 2.2.0 and 3.1.0

Based on Debian Stretch "Slim" and optimized for size:

```
$ docker images | grep docker-node-sass
docker-node-sass                 node6-sass3.1.0        385a1415385b        4 minutes ago       308MB
docker-node-sass                 node6-sass2.2.0        a73a786bc739        5 minutes ago       306MB
```